### PR TITLE
Clear map.visible_tiles only once

### DIFF
--- a/book/src/chapter_5.md
+++ b/book/src/chapter_5.md
@@ -486,7 +486,6 @@ Our creation method also needs to know to add all false to it, just like before:
 
 ```rust
 if viewshed.dirty {
-    for t in map.visible_tiles.iter_mut() { *t = false };
     viewshed.dirty = false;
     viewshed.visible_tiles.clear();
     viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
@@ -494,6 +493,7 @@ if viewshed.dirty {
     // If this is the player, reveal what they can see
     let _p : Option<&Player> = player.get(ent);
     if let Some(_p) = _p {
+        for t in map.visible_tiles.iter_mut() { *t = false };
         for vis in viewshed.visible_tiles.iter() {
             let idx = map.xy_idx(vis.x, vis.y);
             map.revealed_tiles[idx] = true;


### PR DESCRIPTION
It feels wrong to clear map.visible_tiles every time in the outer loop.  Also, what if there's a monster that's keeping track of its own viewshed, and it gets processed after the player?  The code would clear all map visible tiles and forget what the player can see.