### PR TITLE
Fix slight Markdown mishap in chapter 7

### DIFF
--- a/book/src/chapter_7.md
+++ b/book/src/chapter_7.md
@@ -149,7 +149,7 @@ Now we'll make a new component, `BlocksTile`. You should know the drill by now; 
 ```rust
 #[derive(Component, Debug)]
 pub struct BlocksTile {}
-```rust
+```
 
 Then register it in `main.rs`: `gs.ecs.register::<BlocksTile>();`
 


### PR DESCRIPTION
This looked wrong so I fixed it, I hope:

![Ekrano nuotrauka iš 2019-09-14 09-41-29](https://user-images.githubusercontent.com/159967/64904516-e0d4d980-d6d3-11e9-9939-d2e135a30a6b.png)

-- http://bfnightly.bracketproductions.com/rustbook/chapter_7.html