### PR TITLE
Monsters can get hungry too!

### DIFF
--- a/book/src/chapter_19.md
+++ b/book/src/chapter_19.md
@@ -87,7 +87,7 @@ impl<'a> System<'a> for HungerSystem {
                 }
                 RunState::MonsterTurn => {
                     if entity != *player_entity {
-                        proceed = false;
+                        proceed = true;
                     }
                 }
                 _ => proceed = false


### PR DESCRIPTION
(Well, if someone adds the right component.)

The entity != player check makes no sense otherwise, as proceed was false before the match.