### PR TITLE
Fix/input bound checking

### DIFF
--- a/book/src/chapter_2.md
+++ b/book/src/chapter_2.md
@@ -57,6 +57,7 @@ At the top of `main.rs` we add a few lines of code:
 ```rust
 use rltk::{Console, GameState, Rltk, RGB, VirtualKeyCode};
 use specs::prelude::*;
+use std::cmp::{max, min};
 #[macro_use]
 extern crate specs_derive;
 ```
@@ -237,6 +238,7 @@ If you've typed all of that in correctly, your `main.rs` now looks like this:
 ```rust
 use rltk::{Console, GameState, Rltk, RGB};
 use specs::prelude::*;
+use std::cmp::{max, min};
 #[macro_use]
 extern crate specs_derive;
 
@@ -402,6 +404,7 @@ So your code now looks like this:
 ```rust
 use rltk::{Console, GameState, Rltk, RGB};
 use specs::prelude::*;
+use std::cmp::{max, min};
 #[macro_use]
 extern crate specs_derive;
 
@@ -540,13 +543,8 @@ fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
     let mut players = ecs.write_storage::<Player>();
 
     for (_player, pos) in (&mut players, &mut positions).join() {
-        pos.x += delta_x;
-        pos.y += delta_y;
-
-        if pos.x < 0 { pos.x = 0; }
-        if pos.x > 79 { pos.x = 79; }
-        if pos.y < 0 { pos.y = 0; }
-        if pos.y > 49 { pos.y = 49; }
+        pos.x = min(79 , max(0, pos.x + delta_x));
+        pos.y = min(49, max(0, pos.y + delta_y));
     }
 }
 ```
@@ -598,6 +596,7 @@ The source code for this completed example may be found ready-to-run in `chapter
 ```rust
 use rltk::{Console, GameState, Rltk, RGB, VirtualKeyCode};
 use specs::prelude::*;
+use std::cmp::{max, min};
 #[macro_use]
 extern crate specs_derive;
 
@@ -631,13 +630,8 @@ fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
     let mut players = ecs.write_storage::<Player>();
 
     for (_player, pos) in (&mut players, &mut positions).join() {
-        pos.x += delta_x;
-        pos.y += delta_y;
-
-        if pos.x < 0 { pos.x = 0; }
-        if pos.x > 79 { pos.x = 79; }
-        if pos.y < 0 { pos.y = 0; }
-        if pos.y > 49 { pos.y = 49; }
+        pos.x = min(79 , max(0, pos.x + delta_x));
+        pos.y = min(49, max(0, pos.y + delta_y));
     }
 }
 

--- a/book/src/chapter_2.md
+++ b/book/src/chapter_2.md
@@ -544,7 +544,7 @@ fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         pos.y += delta_y;
 
         if pos.x < 0 { pos.x = 0; }
-        if pos.x > 79 { pos.y = 79; }
+        if pos.x > 79 { pos.x = 79; }
         if pos.y < 0 { pos.y = 0; }
         if pos.y > 49 { pos.y = 49; }
     }
@@ -635,7 +635,7 @@ fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         pos.y += delta_y;
 
         if pos.x < 0 { pos.x = 0; }
-        if pos.x > 79 { pos.y = 79; }
+        if pos.x > 79 { pos.x = 79; }
         if pos.y < 0 { pos.y = 0; }
         if pos.y > 49 { pos.y = 49; }
     }

--- a/book/src/chapter_3.md
+++ b/book/src/chapter_3.md
@@ -165,7 +165,7 @@ fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
         }
@@ -259,7 +259,7 @@ fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
         }

--- a/book/src/chapter_3.md
+++ b/book/src/chapter_3.md
@@ -161,13 +161,8 @@ fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
     for (_player, pos) in (&mut players, &mut positions).join() {
         let destination_idx = xy_idx(pos.x + delta_x, pos.y + delta_y);
         if map[destination_idx] != TileType::Wall {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
         }
     }
 }
@@ -184,6 +179,7 @@ The full program now looks like this:
 ```rust
 use rltk::{Console, GameState, Rltk, RGB, VirtualKeyCode};
 use specs::prelude::*;
+use std::cmp::{max, min};
 #[macro_use]
 extern crate specs_derive;
 
@@ -255,13 +251,8 @@ fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
     for (_player, pos) in (&mut players, &mut positions).join() {
         let destination_idx = xy_idx(pos.x + delta_x, pos.y + delta_y);
         if map[destination_idx] != TileType::Wall {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
         }
     }
 }

--- a/book/src/chapter_5.md
+++ b/book/src/chapter_5.md
@@ -449,13 +449,8 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
     for (_player, pos, viewshed) in (&mut players, &mut positions, &mut viewsheds).join() {
         let destination_idx = map.xy_idx(pos.x + delta_x, pos.y + delta_y);
         if map.tiles[destination_idx] != TileType::Wall {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
 
             viewshed.dirty = true;
         }

--- a/book/src/chapter_5.md
+++ b/book/src/chapter_5.md
@@ -453,7 +453,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/book/src/chapter_7.md
+++ b/book/src/chapter_7.md
@@ -267,33 +267,33 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::Paused } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::Y => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::U => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             _ => { return RunState::Paused }

--- a/chapter-02-helloecs/src/main.rs
+++ b/chapter-02-helloecs/src/main.rs
@@ -37,7 +37,7 @@ fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         pos.y += delta_y;
 
         if pos.x < 0 { pos.x = 0; }
-        if pos.x > 79 { pos.y = 79; }
+        if pos.x > 79 { pos.x = 79; }
         if pos.y < 0 { pos.y = 0; }
         if pos.y > 49 { pos.y = 49; }
     }

--- a/chapter-02-helloecs/src/main.rs
+++ b/chapter-02-helloecs/src/main.rs
@@ -1,5 +1,6 @@
 use rltk::{Console, GameState, Rltk, RGB, VirtualKeyCode};
 use specs::prelude::*;
+use std::cmp::{max, min};
 #[macro_use]
 extern crate specs_derive;
 
@@ -33,13 +34,8 @@ fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
     let mut players = ecs.write_storage::<Player>();
 
     for (_player, pos) in (&mut players, &mut positions).join() {
-        pos.x += delta_x;
-        pos.y += delta_y;
-
-        if pos.x < 0 { pos.x = 0; }
-        if pos.x > 79 { pos.x = 79; }
-        if pos.y < 0 { pos.y = 0; }
-        if pos.y > 49 { pos.y = 49; }
+        pos.x = min(79 , max(0, pos.x + delta_x));
+        pos.y = min(49, max(0, pos.y + delta_y));
     }
 }
 

--- a/chapter-03-walkmap/src/main.rs
+++ b/chapter-03-walkmap/src/main.rs
@@ -71,13 +71,8 @@ fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
     for (_player, pos) in (&mut players, &mut positions).join() {
         let destination_idx = xy_idx(pos.x + delta_x, pos.y + delta_y);
         if map[destination_idx] != TileType::Wall {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
         }
     }
 }

--- a/chapter-03-walkmap/src/main.rs
+++ b/chapter-03-walkmap/src/main.rs
@@ -75,7 +75,7 @@ fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
         }

--- a/chapter-04-newmap/src/player.rs
+++ b/chapter-04-newmap/src/player.rs
@@ -10,13 +10,8 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
     for (_player, pos) in (&mut players, &mut positions).join() {
         let destination_idx = xy_idx(pos.x + delta_x, pos.y + delta_y);
         if map[destination_idx] != TileType::Wall {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
         }
     }
 }

--- a/chapter-04-newmap/src/player.rs
+++ b/chapter-04-newmap/src/player.rs
@@ -14,7 +14,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
         }

--- a/chapter-05-fov/src/player.rs
+++ b/chapter-05-fov/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, TileType, State, Map};
 
 pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
@@ -13,13 +14,8 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
     for (_player, pos, viewshed) in (&mut players, &mut positions, &mut viewsheds).join() {
         let destination_idx = map.xy_idx(pos.x + delta_x, pos.y + delta_y);
         if map.tiles[destination_idx] != TileType::Wall {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
 
             viewshed.dirty = true;
         }

--- a/chapter-05-fov/src/player.rs
+++ b/chapter-05-fov/src/player.rs
@@ -17,7 +17,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-06-monsters/src/player.rs
+++ b/chapter-06-monsters/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, TileType, State, Map, RunState};
 
 pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
@@ -13,13 +14,8 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
     for (_player, pos, viewshed) in (&mut players, &mut positions, &mut viewsheds).join() {
         let destination_idx = map.xy_idx(pos.x + delta_x, pos.y + delta_y);
         if map.tiles[destination_idx] != TileType::Wall {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-06-monsters/src/player.rs
+++ b/chapter-06-monsters/src/player.rs
@@ -17,7 +17,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-07-damage/src/player.rs
+++ b/chapter-07-damage/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee};
 
 pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
@@ -25,13 +26,8 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-07-damage/src/player.rs
+++ b/chapter-07-damage/src/player.rs
@@ -42,33 +42,33 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             _ => { return RunState::AwaitingInput }

--- a/chapter-07-damage/src/player.rs
+++ b/chapter-07-damage/src/player.rs
@@ -29,7 +29,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-08-ui/src/player.rs
+++ b/chapter-08-ui/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee};
 
 pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
@@ -25,13 +26,8 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-08-ui/src/player.rs
+++ b/chapter-08-ui/src/player.rs
@@ -42,33 +42,33 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             _ => { return RunState::AwaitingInput }

--- a/chapter-08-ui/src/player.rs
+++ b/chapter-08-ui/src/player.rs
@@ -29,7 +29,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-09-items/src/player.rs
+++ b/chapter-09-items/src/player.rs
@@ -30,7 +30,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-09-items/src/player.rs
+++ b/chapter-09-items/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee, Item,
     gamelog::GameLog, WantsToPickupItem};
 
@@ -26,13 +27,8 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-09-items/src/player.rs
+++ b/chapter-09-items/src/player.rs
@@ -67,33 +67,33 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             // Picking up items

--- a/chapter-10-ranged/src/player.rs
+++ b/chapter-10-ranged/src/player.rs
@@ -30,7 +30,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-10-ranged/src/player.rs
+++ b/chapter-10-ranged/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee, Item,
     gamelog::GameLog, WantsToPickupItem};
 
@@ -26,13 +27,8 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-10-ranged/src/player.rs
+++ b/chapter-10-ranged/src/player.rs
@@ -67,33 +67,33 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             // Picking up items

--- a/chapter-11-loadsave/src/player.rs
+++ b/chapter-11-loadsave/src/player.rs
@@ -30,7 +30,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-11-loadsave/src/player.rs
+++ b/chapter-11-loadsave/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee, Item,
     gamelog::GameLog, WantsToPickupItem};
 
@@ -26,13 +27,8 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-11-loadsave/src/player.rs
+++ b/chapter-11-loadsave/src/player.rs
@@ -67,33 +67,33 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             // Picking up items

--- a/chapter-12-delvingdeeper/src/player.rs
+++ b/chapter-12-delvingdeeper/src/player.rs
@@ -80,33 +80,33 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             // Level changes

--- a/chapter-12-delvingdeeper/src/player.rs
+++ b/chapter-12-delvingdeeper/src/player.rs
@@ -30,7 +30,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-12-delvingdeeper/src/player.rs
+++ b/chapter-12-delvingdeeper/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee, Item,
     gamelog::GameLog, WantsToPickupItem, TileType};
 
@@ -26,13 +27,8 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-13-difficulty/src/player.rs
+++ b/chapter-13-difficulty/src/player.rs
@@ -109,33 +109,33 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             // Skip Turn

--- a/chapter-13-difficulty/src/player.rs
+++ b/chapter-13-difficulty/src/player.rs
@@ -30,7 +30,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-13-difficulty/src/player.rs
+++ b/chapter-13-difficulty/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee, Item,
     gamelog::GameLog, WantsToPickupItem, TileType, Monster};
 
@@ -26,13 +27,8 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-14-gear/src/player.rs
+++ b/chapter-14-gear/src/player.rs
@@ -109,37 +109,37 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             // Skip Turn
-            VirtualKeyCode::Numpad5 => return skip_turn(&mut gs.ecs),
+            VirtualKeyCode::Numpad5 |
             VirtualKeyCode::Space => return skip_turn(&mut gs.ecs),
 
             // Level changes

--- a/chapter-14-gear/src/player.rs
+++ b/chapter-14-gear/src/player.rs
@@ -30,7 +30,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-14-gear/src/player.rs
+++ b/chapter-14-gear/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee, Item,
     gamelog::GameLog, WantsToPickupItem, TileType, Monster};
 
@@ -26,13 +27,8 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-16-nicewalls/src/player.rs
+++ b/chapter-16-nicewalls/src/player.rs
@@ -109,37 +109,37 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             // Skip Turn
-            VirtualKeyCode::Numpad5 => return skip_turn(&mut gs.ecs),
+            VirtualKeyCode::Numpad5 |
             VirtualKeyCode::Space => return skip_turn(&mut gs.ecs),
 
             // Level changes

--- a/chapter-16-nicewalls/src/player.rs
+++ b/chapter-16-nicewalls/src/player.rs
@@ -30,7 +30,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-16-nicewalls/src/player.rs
+++ b/chapter-16-nicewalls/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee, Item,
     gamelog::GameLog, WantsToPickupItem, TileType, Monster};
 
@@ -26,13 +27,8 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-17-blood/src/player.rs
+++ b/chapter-17-blood/src/player.rs
@@ -109,37 +109,37 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             // Skip Turn
-            VirtualKeyCode::Numpad5 => return skip_turn(&mut gs.ecs),
+            VirtualKeyCode::Numpad5 |
             VirtualKeyCode::Space => return skip_turn(&mut gs.ecs),
 
             // Level changes

--- a/chapter-17-blood/src/player.rs
+++ b/chapter-17-blood/src/player.rs
@@ -30,7 +30,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-17-blood/src/player.rs
+++ b/chapter-17-blood/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee, Item,
     gamelog::GameLog, WantsToPickupItem, TileType, Monster};
 
@@ -26,13 +27,8 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-18-particles/src/player.rs
+++ b/chapter-18-particles/src/player.rs
@@ -109,37 +109,37 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             // Skip Turn
-            VirtualKeyCode::Numpad5 => return skip_turn(&mut gs.ecs),
+            VirtualKeyCode::Numpad5 |
             VirtualKeyCode::Space => return skip_turn(&mut gs.ecs),
 
             // Level changes

--- a/chapter-18-particles/src/player.rs
+++ b/chapter-18-particles/src/player.rs
@@ -30,7 +30,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-18-particles/src/player.rs
+++ b/chapter-18-particles/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee, Item,
     gamelog::GameLog, WantsToPickupItem, TileType, Monster};
 
@@ -26,13 +27,8 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-19-food/src/player.rs
+++ b/chapter-19-food/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee, Item,
     gamelog::GameLog, WantsToPickupItem, TileType, Monster, HungerClock, HungerState};
 
@@ -26,13 +27,8 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-19-food/src/player.rs
+++ b/chapter-19-food/src/player.rs
@@ -119,37 +119,37 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             // Skip Turn
-            VirtualKeyCode::Numpad5 => return skip_turn(&mut gs.ecs),
+            VirtualKeyCode::Numpad5 |
             VirtualKeyCode::Space => return skip_turn(&mut gs.ecs),
 
             // Level changes

--- a/chapter-19-food/src/player.rs
+++ b/chapter-19-food/src/player.rs
@@ -30,7 +30,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-20-magicmapping/src/player.rs
+++ b/chapter-20-magicmapping/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee, Item,
     gamelog::GameLog, WantsToPickupItem, TileType, Monster, HungerClock, HungerState};
 
@@ -26,13 +27,8 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-20-magicmapping/src/player.rs
+++ b/chapter-20-magicmapping/src/player.rs
@@ -119,37 +119,37 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             // Skip Turn
-            VirtualKeyCode::Numpad5 => return skip_turn(&mut gs.ecs),
+            VirtualKeyCode::Numpad5 |
             VirtualKeyCode::Space => return skip_turn(&mut gs.ecs),
 
             // Level changes

--- a/chapter-20-magicmapping/src/player.rs
+++ b/chapter-20-magicmapping/src/player.rs
@@ -30,7 +30,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-21-rexmenu/src/player.rs
+++ b/chapter-21-rexmenu/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee, Item,
     gamelog::GameLog, WantsToPickupItem, TileType, Monster, HungerClock, HungerState};
 
@@ -26,13 +27,8 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-21-rexmenu/src/player.rs
+++ b/chapter-21-rexmenu/src/player.rs
@@ -30,7 +30,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             pos.y += delta_y;
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-21-rexmenu/src/player.rs
+++ b/chapter-21-rexmenu/src/player.rs
@@ -119,33 +119,33 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             // Skip Turn

--- a/chapter-22-simpletraps/src/player.rs
+++ b/chapter-22-simpletraps/src/player.rs
@@ -32,7 +32,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             entity_moved.insert(entity, EntityMoved{}).expect("Unable to insert marker");
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-22-simpletraps/src/player.rs
+++ b/chapter-22-simpletraps/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee, Item,
     gamelog::GameLog, WantsToPickupItem, TileType, Monster, HungerClock, HungerState, EntityMoved};
 
@@ -27,14 +28,9 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
             entity_moved.insert(entity, EntityMoved{}).expect("Unable to insert marker");
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-22-simpletraps/src/player.rs
+++ b/chapter-22-simpletraps/src/player.rs
@@ -121,37 +121,37 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             // Skip Turn
-            VirtualKeyCode::Numpad5 => return skip_turn(&mut gs.ecs),
+            VirtualKeyCode::Numpad5 |
             VirtualKeyCode::Space => return skip_turn(&mut gs.ecs),
 
             // Level changes

--- a/chapter-23-generic-map/src/player.rs
+++ b/chapter-23-generic-map/src/player.rs
@@ -32,7 +32,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             entity_moved.insert(entity, EntityMoved{}).expect("Unable to insert marker");
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-23-generic-map/src/player.rs
+++ b/chapter-23-generic-map/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee, Item,
     gamelog::GameLog, WantsToPickupItem, TileType, Monster, HungerClock, HungerState, EntityMoved};
 
@@ -27,14 +28,9 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
             entity_moved.insert(entity, EntityMoved{}).expect("Unable to insert marker");
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-23-generic-map/src/player.rs
+++ b/chapter-23-generic-map/src/player.rs
@@ -121,37 +121,37 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             // Skip Turn
-            VirtualKeyCode::Numpad5 => return skip_turn(&mut gs.ecs),
+            VirtualKeyCode::Numpad5 |
             VirtualKeyCode::Space => return skip_turn(&mut gs.ecs),
 
             // Level changes

--- a/chapter-24-map-testing/src/player.rs
+++ b/chapter-24-map-testing/src/player.rs
@@ -32,7 +32,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             entity_moved.insert(entity, EntityMoved{}).expect("Unable to insert marker");
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-24-map-testing/src/player.rs
+++ b/chapter-24-map-testing/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee, Item,
     gamelog::GameLog, WantsToPickupItem, TileType, Monster, HungerClock, HungerState, EntityMoved};
 
@@ -27,14 +28,9 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
             entity_moved.insert(entity, EntityMoved{}).expect("Unable to insert marker");
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-24-map-testing/src/player.rs
+++ b/chapter-24-map-testing/src/player.rs
@@ -121,37 +121,37 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             // Skip Turn
-            VirtualKeyCode::Numpad5 => return skip_turn(&mut gs.ecs),
+            VirtualKeyCode::Numpad5 |
             VirtualKeyCode::Space => return skip_turn(&mut gs.ecs),
 
             // Level changes

--- a/chapter-25-bsproom-dungeons/src/player.rs
+++ b/chapter-25-bsproom-dungeons/src/player.rs
@@ -32,7 +32,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             entity_moved.insert(entity, EntityMoved{}).expect("Unable to insert marker");
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-25-bsproom-dungeons/src/player.rs
+++ b/chapter-25-bsproom-dungeons/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee, Item,
     gamelog::GameLog, WantsToPickupItem, TileType, Monster, HungerClock, HungerState, EntityMoved};
 
@@ -27,14 +28,9 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
             entity_moved.insert(entity, EntityMoved{}).expect("Unable to insert marker");
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-25-bsproom-dungeons/src/player.rs
+++ b/chapter-25-bsproom-dungeons/src/player.rs
@@ -121,37 +121,37 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             // Skip Turn
-            VirtualKeyCode::Numpad5 => return skip_turn(&mut gs.ecs),
+            VirtualKeyCode::Numpad5 |
             VirtualKeyCode::Space => return skip_turn(&mut gs.ecs),
 
             // Level changes

--- a/chapter-26-bsp-interiors/src/player.rs
+++ b/chapter-26-bsp-interiors/src/player.rs
@@ -32,7 +32,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             entity_moved.insert(entity, EntityMoved{}).expect("Unable to insert marker");
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-26-bsp-interiors/src/player.rs
+++ b/chapter-26-bsp-interiors/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee, Item,
     gamelog::GameLog, WantsToPickupItem, TileType, Monster, HungerClock, HungerState, EntityMoved};
 
@@ -27,14 +28,9 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
             entity_moved.insert(entity, EntityMoved{}).expect("Unable to insert marker");
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-26-bsp-interiors/src/player.rs
+++ b/chapter-26-bsp-interiors/src/player.rs
@@ -121,37 +121,37 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             // Skip Turn
-            VirtualKeyCode::Numpad5 => return skip_turn(&mut gs.ecs),
+            VirtualKeyCode::Numpad5 |
             VirtualKeyCode::Space => return skip_turn(&mut gs.ecs),
 
             // Level changes

--- a/chapter-27-cellular-automota/src/player.rs
+++ b/chapter-27-cellular-automota/src/player.rs
@@ -32,7 +32,7 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
             entity_moved.insert(entity, EntityMoved{}).expect("Unable to insert marker");
 
             if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.y = 79; }
+            if pos.x > 79 { pos.x = 79; }
             if pos.y < 0 { pos.y = 0; }
             if pos.y > 49 { pos.y = 49; }
 

--- a/chapter-27-cellular-automota/src/player.rs
+++ b/chapter-27-cellular-automota/src/player.rs
@@ -2,6 +2,7 @@ extern crate rltk;
 use rltk::{VirtualKeyCode, Rltk, Point};
 extern crate specs;
 use specs::prelude::*;
+use std::cmp::{max, min};
 use super::{Position, Player, Viewshed, State, Map, RunState, CombatStats, WantsToMelee, Item,
     gamelog::GameLog, WantsToPickupItem, TileType, Monster, HungerClock, HungerState, EntityMoved};
 
@@ -27,14 +28,9 @@ pub fn try_move_player(delta_x: i32, delta_y: i32, ecs: &mut World) {
         }
 
         if !map.blocked[destination_idx] {
-            pos.x += delta_x;
-            pos.y += delta_y;
+            pos.x = min(79 , max(0, pos.x + delta_x));
+            pos.y = min(49, max(0, pos.y + delta_y));
             entity_moved.insert(entity, EntityMoved{}).expect("Unable to insert marker");
-
-            if pos.x < 0 { pos.x = 0; }
-            if pos.x > 79 { pos.x = 79; }
-            if pos.y < 0 { pos.y = 0; }
-            if pos.y > 49 { pos.y = 49; }
 
             viewshed.dirty = true;
             let mut ppos = ecs.write_resource::<Point>();

--- a/chapter-27-cellular-automota/src/player.rs
+++ b/chapter-27-cellular-automota/src/player.rs
@@ -121,37 +121,37 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
     match ctx.key {
         None => { return RunState::AwaitingInput } // Nothing happened
         Some(key) => match key {
-            VirtualKeyCode::Left => try_move_player(-1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad4 => try_move_player(-1, 0, &mut gs.ecs),
+            VirtualKeyCode::Left |
+            VirtualKeyCode::Numpad4 |
             VirtualKeyCode::H => try_move_player(-1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Right => try_move_player(1, 0, &mut gs.ecs),
-            VirtualKeyCode::Numpad6 => try_move_player(1, 0, &mut gs.ecs),            
+            VirtualKeyCode::Right |
+            VirtualKeyCode::Numpad6 |
             VirtualKeyCode::L => try_move_player(1, 0, &mut gs.ecs),
 
-            VirtualKeyCode::Up => try_move_player(0, -1, &mut gs.ecs),
-            VirtualKeyCode::Numpad8 => try_move_player(0, -1, &mut gs.ecs),
+            VirtualKeyCode::Up |
+            VirtualKeyCode::Numpad8 |
             VirtualKeyCode::K => try_move_player(0, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Down => try_move_player(0, 1, &mut gs.ecs),
-            VirtualKeyCode::Numpad2 => try_move_player(0, 1, &mut gs.ecs),
+            VirtualKeyCode::Down |
+            VirtualKeyCode::Numpad2 |
             VirtualKeyCode::J => try_move_player(0, 1, &mut gs.ecs),
 
             // Diagonals
-            VirtualKeyCode::Numpad9 => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad9 |
             VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad7 => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Numpad7 |
             VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad3 => try_move_player(1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),
 
-            VirtualKeyCode::Numpad1 => try_move_player(-1, 1, &mut gs.ecs),
+            VirtualKeyCode::Numpad1 |
             VirtualKeyCode::B => try_move_player(-1, 1, &mut gs.ecs),
 
             // Skip Turn
-            VirtualKeyCode::Numpad5 => return skip_turn(&mut gs.ecs),
+            VirtualKeyCode::Numpad5 |
             VirtualKeyCode::Space => return skip_turn(&mut gs.ecs),
 
             // Level changes


### PR DESCRIPTION
This pr contains the following improvements:

1. Fix player input bounds checking for x-axis
2. Refactor input bounds checking by clamping values to a range with `min` and `max` functions
3. Simplify player input handling by matching multiple arms to the same statement

The pr is quite lengthy because the same changes have been done to all chapters containing the same code. I tried to make sure that I got them all with by grepping the whole repository. 