### PR TITLE
Fixes padding rendering in tooltip placed to the right.

### DIFF
--- a/chapter-08-ui/src/gui.rs
+++ b/chapter-08-ui/src/gui.rs
@@ -68,10 +68,10 @@ fn draw_tooltips(ecs: &World, ctx : &mut Rltk) {
             let left_x = mouse_pos.0 +3;
             let mut y = mouse_pos.1;
             for s in tooltip.iter() {
-                ctx.print_color(left_x, y, RGB::named(rltk::WHITE), RGB::named(rltk::GREY), &s.to_string());
+                ctx.print_color(left_x + 1, y, RGB::named(rltk::WHITE), RGB::named(rltk::GREY), &s.to_string());
                 let padding = (width - s.len() as i32)-1;
                 for i in 0..padding {
-                    ctx.print_color(left_x + s.len() as i32 + i, y, RGB::named(rltk::WHITE), RGB::named(rltk::GREY), &" ".to_string());
+                    ctx.print_color(arrow_pos.x + 1 + i, y, RGB::named(rltk::WHITE), RGB::named(rltk::GREY), &" ".to_string());
                 }
                 y += 1;
             }


### PR DESCRIPTION
Padding in tooltips placed to the right of the mouse cursor was rendered wrong, behind the entity's name instead of in-between arrow and said name.

This fixes this small problem in the source code for chapter 9 (UI). Later chapters where not modified (mostly due to me not having made it there yet).

Edit: Of course, I'm talking about tooltips to the _right_ of the mouse cursor, not the left. I guess writing PR's at 2 in the morning isn't a great idea after all.