### PR TITLE
Fix healing bug by using i32::min instead of i32::max

### DIFF
--- a/chapter-10-ranged/src/inventory_system.rs
+++ b/chapter-10-ranged/src/inventory_system.rs
@@ -97,7 +97,7 @@ impl<'a> System<'a> for ItemUseSystem {
                     for target in targets.iter() {
                         let stats = combat_stats.get_mut(*target);
                         if let Some(stats) = stats {
-                            stats.hp = i32::max(stats.max_hp, stats.hp + healer.heal_amount);
+                            stats.hp = i32::min(stats.max_hp, stats.hp + healer.heal_amount);
                             if entity == *player_entity {
                                 gamelog.entries.insert(0, format!("You use the {}, healing {} hp.", names.get(useitem.item).unwrap().name, healer.heal_amount));
                             }

--- a/chapter-11-loadsave/src/inventory_system.rs
+++ b/chapter-11-loadsave/src/inventory_system.rs
@@ -97,7 +97,7 @@ impl<'a> System<'a> for ItemUseSystem {
                     for target in targets.iter() {
                         let stats = combat_stats.get_mut(*target);
                         if let Some(stats) = stats {
-                            stats.hp = i32::max(stats.max_hp, stats.hp + healer.heal_amount);
+                            stats.hp = i32::min(stats.max_hp, stats.hp + healer.heal_amount);
                             if entity == *player_entity {
                                 gamelog.entries.insert(0, format!("You use the {}, healing {} hp.", names.get(useitem.item).unwrap().name, healer.heal_amount));
                             }

--- a/chapter-12-delvingdeeper/src/inventory_system.rs
+++ b/chapter-12-delvingdeeper/src/inventory_system.rs
@@ -97,7 +97,7 @@ impl<'a> System<'a> for ItemUseSystem {
                     for target in targets.iter() {
                         let stats = combat_stats.get_mut(*target);
                         if let Some(stats) = stats {
-                            stats.hp = i32::max(stats.max_hp, stats.hp + healer.heal_amount);
+                            stats.hp = i32::min(stats.max_hp, stats.hp + healer.heal_amount);
                             if entity == *player_entity {
                                 gamelog.entries.insert(0, format!("You use the {}, healing {} hp.", names.get(useitem.item).unwrap().name, healer.heal_amount));
                             }

--- a/chapter-13-difficulty/src/inventory_system.rs
+++ b/chapter-13-difficulty/src/inventory_system.rs
@@ -97,7 +97,7 @@ impl<'a> System<'a> for ItemUseSystem {
                     for target in targets.iter() {
                         let stats = combat_stats.get_mut(*target);
                         if let Some(stats) = stats {
-                            stats.hp = i32::max(stats.max_hp, stats.hp + healer.heal_amount);
+                            stats.hp = i32::min(stats.max_hp, stats.hp + healer.heal_amount);
                             if entity == *player_entity {
                                 gamelog.entries.insert(0, format!("You use the {}, healing {} hp.", names.get(useitem.item).unwrap().name, healer.heal_amount));
                             }

--- a/chapter-14-gear/src/inventory_system.rs
+++ b/chapter-14-gear/src/inventory_system.rs
@@ -133,7 +133,7 @@ impl<'a> System<'a> for ItemUseSystem {
                     for target in targets.iter() {
                         let stats = combat_stats.get_mut(*target);
                         if let Some(stats) = stats {
-                            stats.hp = i32::max(stats.max_hp, stats.hp + healer.heal_amount);
+                            stats.hp = i32::min(stats.max_hp, stats.hp + healer.heal_amount);
                             if entity == *player_entity {
                                 gamelog.entries.insert(0, format!("You use the {}, healing {} hp.", names.get(useitem.item).unwrap().name, healer.heal_amount));
                             }

--- a/chapter-16-nicewalls/src/inventory_system.rs
+++ b/chapter-16-nicewalls/src/inventory_system.rs
@@ -133,7 +133,7 @@ impl<'a> System<'a> for ItemUseSystem {
                     for target in targets.iter() {
                         let stats = combat_stats.get_mut(*target);
                         if let Some(stats) = stats {
-                            stats.hp = i32::max(stats.max_hp, stats.hp + healer.heal_amount);
+                            stats.hp = i32::min(stats.max_hp, stats.hp + healer.heal_amount);
                             if entity == *player_entity {
                                 gamelog.entries.insert(0, format!("You use the {}, healing {} hp.", names.get(useitem.item).unwrap().name, healer.heal_amount));
                             }


### PR DESCRIPTION
I found this healing bug affecting chapters 10-16.

Using i32::max will either heal to max hp or cause health to exceed max hp,
which is not desired. This was probably a simple typo. :)