### PR TITLE
Fix broken specs book link

### DIFF
--- a/book/src/chapter_3.md
+++ b/book/src/chapter_3.md
@@ -102,7 +102,7 @@ Specs includes a concept of "resources" - shared data the whole ECS can use. So 
 gs.ecs.insert(new_map());
 ```
 
-The map is now available from anywhere the ECS can see! Now inside your code, you can access the map with the rather unwieldy `let map = self.ecs.get_mut::<Vec<TileType>>();`; it's available to systems in an easier fashion. There's actually *several* ways to get the value of map, including `ecs.get`, `ecs.fetch`. `get_mut` obtains a "mutable" (you can change it) reference to the map - wrapped in an optional (in case the map isn't there). `fetch` skips the `Option` type and gives you a map directly. You can learn more about this [in the Specs Book](https://slide-rs.github.io/specs/04_resources.html).
+The map is now available from anywhere the ECS can see! Now inside your code, you can access the map with the rather unwieldy `let map = self.ecs.get_mut::<Vec<TileType>>();`; it's available to systems in an easier fashion. There's actually *several* ways to get the value of map, including `ecs.get`, `ecs.fetch`. `get_mut` obtains a "mutable" (you can change it) reference to the map - wrapped in an optional (in case the map isn't there). `fetch` skips the `Option` type and gives you a map directly. You can learn more about this [in the Specs Book](https://specs.amethyst.rs/docs/tutorials/04_resources.html).
 
 ## Draw the map
 


### PR DESCRIPTION
I think specs got moved under amethyst and the book got moved. This should also be an evergreen link 😄