### PR TITLE
Fix typo in waveform_collapse/constraints.rs (chapter 33)

### DIFF
--- a/book/src/chapter_33.md
+++ b/book/src/chapter_33.md
@@ -705,7 +705,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-33-wfc/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-33-wfc/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-45-raws1/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-45-raws1/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-46-raws2/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-46-raws2/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-47-town1/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-47-town1/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-48-town2/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-48-town2/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-49-town3/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-49-town3/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-50-stats/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-50-stats/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-51-gear/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-51-gear/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-52-ui/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-52-ui/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-53-woods/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-53-woods/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-54-xp/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-54-xp/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-55-backtrack/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-55-backtrack/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-56-caverns/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-56-caverns/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-57-ai/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-57-ai/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-58-itemstats/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-58-itemstats/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-59-caverns2/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-59-caverns2/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-60-caverns3/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-60-caverns3/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-61-townportal/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-61-townportal/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-62-magicitems/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-62-magicitems/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-63-effects/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-63-effects/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-64-curses/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-64-curses/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-65-items/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-65-items/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-66-spells/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-66-spells/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-67-dragon/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-67-dragon/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-68-mushrooms/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-68-mushrooms/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-69-mushrooms2/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-69-mushrooms2/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;

--- a/chapter-70-missiles/src/map_builders/waveform_collapse/constraints.rs
+++ b/chapter-70-missiles/src/map_builders/waveform_collapse/constraints.rs
@@ -97,7 +97,7 @@ pub fn render_pattern_to_map(map : &mut Map, chunk: &MapChunk, chunk_size: i32, 
             map.tiles[map_idx] = TileType::DownStairs;
         }
     }
-    for (x,eastbound) in chunk.exits[2].iter().enumerate() {
+    for (x,eastbound) in chunk.exits[3].iter().enumerate() {
         if *eastbound {
             let map_idx = map.xy_idx(start_x + chunk_size - 1, start_y + x as i32);
             map.tiles[map_idx] = TileType::DownStairs;


### PR DESCRIPTION
There was a duplicated index when rendering exits, it can be seen in images from chapter 33. I did fix the code in all chapters, but images in chapter 33 are left intact.