### PR TITLE
Redirect links from rltk_rs to bracket-lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Roguelike Tutorial - in Rust
 
-Welcome to the Roguelike Tutorial - in Rust. This is intended to accompany [rltk_rs](https://github.com/thebracket/rltk_rs), my roguelike terminal library for Rust. You can read the ready-formatted version here: [https://bfnightly.bracketproductions.com/rustbook/](https://bfnightly.bracketproductions.com/rustbook/).
+Welcome to the Roguelike Tutorial - in Rust. This is intended to accompany [rltk_rs](https://github.com/thebracket/bracket-lib), my roguelike terminal library for Rust. You can read the ready-formatted version here: [https://bfnightly.bracketproductions.com/rustbook/](https://bfnightly.bracketproductions.com/rustbook/).

--- a/book/src/chapter_0.md
+++ b/book/src/chapter_0.md
@@ -10,7 +10,7 @@
 
 ---
 
-Every year, the fine fellows over at [r/roguelikedev](https://www.reddit.com/r/roguelikedev/new/) run a *Tutorial Tuesday* series - encouraging new programmers to join the ranks of roguelike developers. Most languages end up being represented, and this year (2019) I decided that I'd use it as an excuse to learn Rust. I didn't really want to use `libtcod`, the default engine - so I created my own, [RLTK](https://github.com/thebracket/rltk_rs). My initial entry into the series isn't very good, but I learned a lot from it - you can find it [here](https://github.com/thebracket/rustyroguelike), if you are curious.
+Every year, the fine fellows over at [r/roguelikedev](https://www.reddit.com/r/roguelikedev/new/) run a *Tutorial Tuesday* series - encouraging new programmers to join the ranks of roguelike developers. Most languages end up being represented, and this year (2019) I decided that I'd use it as an excuse to learn Rust. I didn't really want to use `libtcod`, the default engine - so I created my own, [RLTK](https://github.com/thebracket/bracket-lib). My initial entry into the series isn't very good, but I learned a lot from it - you can find it [here](https://github.com/thebracket/rustyroguelike), if you are curious.
 
 The series always points people towards an excellent series of tutorials, using Python and `libtcod`. You can find it [here](http://rogueliketutorials.com/tutorials/tcod/). Section 1 of this tutorial mirrors the structure of this tutorial - and tries to take you from zero (*how do I open a console to say Hello Rust*) to hero (*equipping items to fight foes in a multi-level dungeon*). I'm hoping to continue to extend the series.
 

--- a/book/src/chapter_1.md
+++ b/book/src/chapter_1.md
@@ -117,7 +117,7 @@ Cargo also supports *extensions* - that is, plugins that make it do even more. T
 
 ### Making a new project
 
-Lets modify the newly created "hello world" project to make use of [RLTK](https://github.com/thebracket/rltk_rs) - the Roguelike Toolkit.
+Lets modify the newly created "hello world" project to make use of [RLTK](https://github.com/thebracket/bracket-lib) - the Roguelike Toolkit.
 
 ## Setup Cargo.toml
 

--- a/book/src/chapter_44.md
+++ b/book/src/chapter_44.md
@@ -126,7 +126,7 @@ None! It would be nice to have once tiles are done, but fully voicing a modern R
 
 ### Technical Description
 
-The game will be written in Rust, using [RLTK_RS](https://github.com/thebracket/rltk_rs) for its back-end. It will support all the platforms on which Rust can compile and link to OpenGL, including Web Assembly for browser-based play.
+The game will be written in Rust, using [rltk_rs](https://github.com/thebracket/bracket-lib) for its back-end. It will support all the platforms on which Rust can compile and link to OpenGL, including Web Assembly for browser-based play.
 
 ### Marketing and Funding
 


### PR DESCRIPTION
Following up on the same theme in updating the main repository so that all links properly point to bracket-lib on GitHub!