### PR TITLE
Do not implement diagonals in get_available_exits early

### DIFF
--- a/book/src/chapter_7.md
+++ b/book/src/chapter_7.md
@@ -42,12 +42,6 @@ fn get_available_exits(&self, idx:usize) -> rltk::SmallVec<[(usize, f32); 10]> {
     if self.is_exit_valid(x, y-1) { exits.push((idx-w, 1.0)) };
     if self.is_exit_valid(x, y+1) { exits.push((idx+w, 1.0)) };
 
-    // Diagonals
-    if self.is_exit_valid(x-1, y-1) { exits.push(((idx-w)-1, 1.45)); }
-    if self.is_exit_valid(x+1, y-1) { exits.push(((idx-w)+1, 1.45)); }
-    if self.is_exit_valid(x-1, y+1) { exits.push(((idx+w)-1, 1.45)); }
-    if self.is_exit_valid(x+1, y+1) { exits.push(((idx+w)+1, 1.45)); }
-
     exits
 }
 ```


### PR DESCRIPTION
The diagonal directions in the `get_available_exits` function is does
not need to be implemented until later in the chapters, and is done so
[here](https://github.com/thebracket/rustrogueliketutorial/blob/master/book/src/chapter_7.md#allowing-diagonal-movement). This
PR cleans up the earlier implementation so that the reader doesnt get
confused by an early implementation of diagonals that is not needed.