### PR TITLE
Fix FOV bottom-right bounds checking

### DIFF
--- a/book/src/chapter_22.md
+++ b/book/src/chapter_22.md
@@ -430,7 +430,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/book/src/chapter_5.md
+++ b/book/src/chapter_5.md
@@ -247,7 +247,7 @@ impl<'a> System<'a> for VisibilitySystem {
         for (viewshed,pos) in (&mut viewshed, &pos).join() {
             viewshed.visible_tiles.clear();
             viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-            viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+            viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
         }
     }
 }
@@ -386,7 +386,7 @@ impl<'a> System<'a> for VisibilitySystem {
         for (ent,viewshed,pos) in (&entities, &mut viewshed, &pos).join() {
             viewshed.visible_tiles.clear();
             viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-            viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+            viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
             // If this is the player, reveal what they can see
             let p : Option<&Player> = player.get(ent);
@@ -468,7 +468,7 @@ if viewshed.dirty {
     viewshed.dirty = false;
     viewshed.visible_tiles.clear();
     viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-    viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+    viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
     // If this is the player, reveal what they can see
     let _p : Option<&Player> = player.get(ent);

--- a/chapter-05-fov/src/visibility_system.rs
+++ b/chapter-05-fov/src/visibility_system.rs
@@ -19,7 +19,7 @@ impl<'a> System<'a> for VisibilitySystem {
                 viewshed.dirty = false;
                 viewshed.visible_tiles.clear();
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-06-monsters/src/visibility_system.rs
+++ b/chapter-06-monsters/src/visibility_system.rs
@@ -18,7 +18,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-07-damage/src/visibility_system.rs
+++ b/chapter-07-damage/src/visibility_system.rs
@@ -18,7 +18,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-08-ui/src/visibility_system.rs
+++ b/chapter-08-ui/src/visibility_system.rs
@@ -18,7 +18,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-09-items/src/visibility_system.rs
+++ b/chapter-09-items/src/visibility_system.rs
@@ -18,7 +18,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-10-ranged/src/visibility_system.rs
+++ b/chapter-10-ranged/src/visibility_system.rs
@@ -18,7 +18,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-11-loadsave/src/visibility_system.rs
+++ b/chapter-11-loadsave/src/visibility_system.rs
@@ -18,7 +18,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-12-delvingdeeper/src/visibility_system.rs
+++ b/chapter-12-delvingdeeper/src/visibility_system.rs
@@ -18,7 +18,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-13-difficulty/src/visibility_system.rs
+++ b/chapter-13-difficulty/src/visibility_system.rs
@@ -18,7 +18,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-14-gear/src/visibility_system.rs
+++ b/chapter-14-gear/src/visibility_system.rs
@@ -18,7 +18,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-16-nicewalls/src/visibility_system.rs
+++ b/chapter-16-nicewalls/src/visibility_system.rs
@@ -18,7 +18,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-17-blood/src/visibility_system.rs
+++ b/chapter-17-blood/src/visibility_system.rs
@@ -18,7 +18,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-18-particles/src/visibility_system.rs
+++ b/chapter-18-particles/src/visibility_system.rs
@@ -18,7 +18,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-19-food/src/visibility_system.rs
+++ b/chapter-19-food/src/visibility_system.rs
@@ -18,7 +18,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-21-rexmenu/src/visibility_system.rs
+++ b/chapter-21-rexmenu/src/visibility_system.rs
@@ -18,7 +18,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-22-simpletraps/src/visibility_system.rs
+++ b/chapter-22-simpletraps/src/visibility_system.rs
@@ -24,7 +24,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-23-generic-map/src/visibility_system.rs
+++ b/chapter-23-generic-map/src/visibility_system.rs
@@ -24,7 +24,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-24-map-testing/src/visibility_system.rs
+++ b/chapter-24-map-testing/src/visibility_system.rs
@@ -24,7 +24,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-25-bsproom-dungeons/src/visibility_system.rs
+++ b/chapter-25-bsproom-dungeons/src/visibility_system.rs
@@ -24,7 +24,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-26-bsp-interiors/src/visibility_system.rs
+++ b/chapter-26-bsp-interiors/src/visibility_system.rs
@@ -24,7 +24,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-27-cellular-automata/src/visibility_system.rs
+++ b/chapter-27-cellular-automata/src/visibility_system.rs
@@ -24,7 +24,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-28-drunkards-walk/src/visibility_system.rs
+++ b/chapter-28-drunkards-walk/src/visibility_system.rs
@@ -24,7 +24,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-29-mazes/src/visibility_system.rs
+++ b/chapter-29-mazes/src/visibility_system.rs
@@ -24,7 +24,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-30-dla/src/visibility_system.rs
+++ b/chapter-30-dla/src/visibility_system.rs
@@ -24,7 +24,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-31-symmetry/src/visibility_system.rs
+++ b/chapter-31-symmetry/src/visibility_system.rs
@@ -24,7 +24,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-32-voronoi/src/visibility_system.rs
+++ b/chapter-32-voronoi/src/visibility_system.rs
@@ -24,7 +24,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-33-wfc/src/visibility_system.rs
+++ b/chapter-33-wfc/src/visibility_system.rs
@@ -24,7 +24,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-34-vaults/src/visibility_system.rs
+++ b/chapter-34-vaults/src/visibility_system.rs
@@ -24,7 +24,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-35-vaults2/src/visibility_system.rs
+++ b/chapter-35-vaults2/src/visibility_system.rs
@@ -24,7 +24,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-36-layers/src/visibility_system.rs
+++ b/chapter-36-layers/src/visibility_system.rs
@@ -24,7 +24,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-37-layers2/src/visibility_system.rs
+++ b/chapter-37-layers2/src/visibility_system.rs
@@ -24,7 +24,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-38-rooms/src/visibility_system.rs
+++ b/chapter-38-rooms/src/visibility_system.rs
@@ -24,7 +24,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-39-halls/src/visibility_system.rs
+++ b/chapter-39-halls/src/visibility_system.rs
@@ -24,7 +24,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-40-doors/src/visibility_system.rs
+++ b/chapter-40-doors/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-41-camera/src/visibility_system.rs
+++ b/chapter-41-camera/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-45-raws1/src/visibility_system.rs
+++ b/chapter-45-raws1/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-46-raws2/src/visibility_system.rs
+++ b/chapter-46-raws2/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-47-town1/src/visibility_system.rs
+++ b/chapter-47-town1/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-48-town2/src/visibility_system.rs
+++ b/chapter-48-town2/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-49-town3/src/visibility_system.rs
+++ b/chapter-49-town3/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-50-stats/src/visibility_system.rs
+++ b/chapter-50-stats/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-51-gear/src/visibility_system.rs
+++ b/chapter-51-gear/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-52-ui/src/visibility_system.rs
+++ b/chapter-52-ui/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-53-woods/src/visibility_system.rs
+++ b/chapter-53-woods/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-54-xp/src/visibility_system.rs
+++ b/chapter-54-xp/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-55-backtrack/src/visibility_system.rs
+++ b/chapter-55-backtrack/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-56-caverns/src/visibility_system.rs
+++ b/chapter-56-caverns/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-57-ai/src/visibility_system.rs
+++ b/chapter-57-ai/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-57a-spatial/src/visibility_system.rs
+++ b/chapter-57a-spatial/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-58-itemstats/src/visibility_system.rs
+++ b/chapter-58-itemstats/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-59-caverns2/src/visibility_system.rs
+++ b/chapter-59-caverns2/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-60-caverns3/src/visibility_system.rs
+++ b/chapter-60-caverns3/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-61-townportal/src/visibility_system.rs
+++ b/chapter-61-townportal/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-62-magicitems/src/visibility_system.rs
+++ b/chapter-62-magicitems/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-63-effects/src/visibility_system.rs
+++ b/chapter-63-effects/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-64-curses/src/visibility_system.rs
+++ b/chapter-64-curses/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-65-items/src/visibility_system.rs
+++ b/chapter-65-items/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-66-spells/src/visibility_system.rs
+++ b/chapter-66-spells/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-67-dragon/src/visibility_system.rs
+++ b/chapter-67-dragon/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-68-mushrooms/src/visibility_system.rs
+++ b/chapter-68-mushrooms/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-69-mushrooms2/src/visibility_system.rs
+++ b/chapter-69-mushrooms2/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-70-missiles/src/visibility_system.rs
+++ b/chapter-70-missiles/src/visibility_system.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-71-logging/src/visibility_system.rs
+++ b/chapter-71-logging/src/visibility_system.rs
@@ -30,7 +30,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-72-textlayers/src/visibility_system.rs
+++ b/chapter-72-textlayers/src/visibility_system.rs
@@ -30,7 +30,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-73-systems/src/systems/visibility_system.rs
+++ b/chapter-73-systems/src/systems/visibility_system.rs
@@ -29,7 +29,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);

--- a/chapter-74-darkcity/src/systems/visibility_system.rs
+++ b/chapter-74-darkcity/src/systems/visibility_system.rs
@@ -29,7 +29,7 @@ impl<'a> System<'a> for VisibilitySystem {
             if viewshed.dirty {
                 viewshed.dirty = false;
                 viewshed.visible_tiles = field_of_view(Point::new(pos.x, pos.y), viewshed.range, &*map);
-                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width-1 && p.y >= 0 && p.y < map.height-1 );
+                viewshed.visible_tiles.retain(|p| p.x >= 0 && p.x < map.width && p.y >= 0 && p.y < map.height );
 
                 // If this is the player, reveal what they can see
                 let _p : Option<&Player> = player.get(ent);


### PR DESCRIPTION
Fixes issue #131.

The old bounds checking code used the inequalities `p.x < map.width - 1` and `p.y < map.height - 1`. This means that when p.x is 79, or p.y is 49, visibility is never checked, even though there actually are tiles in those locations. Removing the `- 1` part from each inequality allows these tiles to be checked.

See issue #131 for a screenshot of the VisibilitySystem behaviour without this fix. See the screenshot below for the fixed behaviour.

![image](https://user-images.githubusercontent.com/6743441/81507527-f1654000-92b2-11ea-931f-1d2ebc708834.png)
