### PR TITLE
Fix the scroll that is not deleted from the inventory

### DIFF
--- a/chapter-10-ranged/src/inventory_system.rs
+++ b/chapter-10-ranged/src/inventory_system.rs
@@ -140,6 +140,7 @@ impl<'a> System<'a> for ItemUseSystem {
                                 let item_name = names.get(useitem.item).unwrap();
                                 gamelog.entries.push(format!("You use {} on {}, confusing them.", item_name.name, mob_name.name));
                             }
+                            used_item = true;
                         }
                     }
                 }


### PR DESCRIPTION
The confusion scroll was not removed from inventory in chapter 10 because `used_item = true;` was skipped