### PR TITLE
Remove unnecessary derive

### DIFF
--- a/book/src/chapter_7.md
+++ b/book/src/chapter_7.md
@@ -447,7 +447,7 @@ If you `cargo run` this, you'll see that you can walk up to a mob and try to mov
 We're going to do this in an ECS way, so there's a bit of boilerplate. In `components.rs`, we add a component indicating an intent to attack:
 
 ```rust
-#[derive(Component, Debug, ConvertSaveload, Clone)]
+#[derive(Component, Debug, Clone)]
 pub struct WantsToMelee {
     pub target : Entity
 }


### PR DESCRIPTION
No longer use derive ConvertSaveload. Fixes #142 