### PR TITLE
fix: missing closing bracket in markdown link

### DIFF
--- a/book/src/chapter_3.md
+++ b/book/src/chapter_3.md
@@ -10,7 +10,7 @@
 
 ---
 
-The remainder of this tutorial will be dedicated to making a Roguelike. [Rogue](https://en.wikipedia.org/wiki/Rogue_(video_game) appeared in 1980, as a text-mode dungeon exploration game. It has spawned an entire genre of "roguelikes": procedurally generated maps, hunting an objective over multiple levels and "permadeath" (restart when you die). The definition is the source of many online fights; I'd rather avoid that!
+The remainder of this tutorial will be dedicated to making a Roguelike. [Rogue](https://en.wikipedia.org/wiki/Rogue_(video_game)) appeared in 1980, as a text-mode dungeon exploration game. It has spawned an entire genre of "roguelikes": procedurally generated maps, hunting an objective over multiple levels and "permadeath" (restart when you die). The definition is the source of many online fights; I'd rather avoid that!
 
 A Roguelike without a map to explore is a bit pointless, so in this chapter we'll put together a basic map, draw it, and let your player walk around a bit. We're starting with the code from chapter 2, but with the red smiley faces (and their leftward tendencies) removed.
 


### PR DESCRIPTION
Small fix for incorrect markdown link in Chapter3

<img width="834" alt="ss2020-12-14 163951" src="https://user-images.githubusercontent.com/13163893/102102214-d69c1080-3e2b-11eb-8b48-8f12f652e6f6.png">
