### PR TITLE
Chapter 9: Fix wrong RNG offsets.

### DIFF
--- a/book/src/chapter_9.md
+++ b/book/src/chapter_9.md
@@ -140,9 +140,9 @@ pub fn spawn_room(ecs: &mut World, room : &Rect) {
     // Scope to keep the borrow checker happy
     {
         let mut rng = ecs.write_resource::<RandomNumberGenerator>();
-        let num_monsters = rng.roll_dice(1, MAX_MONSTERS + 2) - 3;
+        let num_monsters = rng.roll_dice(1, MAX_MONSTERS + 1) - 1;
 
-        for _i in 0 .. num_monsters {
+        for _i in 0..num_monsters {
             let mut added = false;
             while !added {
                 let x = (room.x1 + rng.roll_dice(1, i32::abs(room.x2 - room.x1))) as usize;
@@ -229,10 +229,10 @@ pub fn spawn_room(ecs: &mut World, room : &Rect) {
     // Scope to keep the borrow checker happy
     {
         let mut rng = ecs.write_resource::<RandomNumberGenerator>();
-        let num_monsters = rng.roll_dice(1, MAX_MONSTERS + 2) - 3;
-        let num_items = rng.roll_dice(1, MAX_ITEMS + 2) - 3;
+        let num_monsters = rng.roll_dice(1, MAX_MONSTERS + 1) - 1;
+        let num_items = rng.roll_dice(1, MAX_ITEMS + 1) - 1;
 
-        for _i in 0 .. num_monsters {
+        for _i in 0..num_monsters {
             let mut added = false;
             while !added {
                 let x = (room.x1 + rng.roll_dice(1, i32::abs(room.x2 - room.x1))) as usize;
@@ -245,7 +245,7 @@ pub fn spawn_room(ecs: &mut World, room : &Rect) {
             }
         }
 
-        for _i in 0 .. num_items {
+        for _i in 0..num_items {
             let mut added = false;
             while !added {
                 let x = (room.x1 + rng.roll_dice(1, i32::abs(room.x2 - room.x1))) as usize;

--- a/chapter-09-items/src/spawner.rs
+++ b/chapter-09-items/src/spawner.rs
@@ -31,10 +31,10 @@ pub fn spawn_room(ecs: &mut World, room : &Rect) {
     // Scope to keep the borrow checker happy
     {
         let mut rng = ecs.write_resource::<RandomNumberGenerator>();
-        let num_monsters = rng.roll_dice(1, MAX_MONSTERS + 2) - 3;
-        let num_items = rng.roll_dice(1, MAX_ITEMS + 2) - 3;
+        let num_monsters = rng.roll_dice(1, MAX_MONSTERS + 1) - 1;
+        let num_items = rng.roll_dice(1, MAX_ITEMS + 1) - 1;
 
-        for _i in 0 .. num_monsters {
+        for _i in 0..num_monsters {
             let mut added = false;
             while !added {
                 let x = (room.x1 + rng.roll_dice(1, i32::abs(room.x2 - room.x1))) as usize;
@@ -47,7 +47,7 @@ pub fn spawn_room(ecs: &mut World, room : &Rect) {
             }
         }
 
-        for _i in 0 .. num_items {
+        for _i in 0..num_items {
             let mut added = false;
             while !added {
                 let x = (room.x1 + rng.roll_dice(1, i32::abs(room.x2 - room.x1))) as usize;


### PR DESCRIPTION
Let's say MAX_MONSTERS = 4.
Numbers from 0 to 4 inclusive is the wanted result.

`rng.roll_dice(1, MAX_MONSTERS);` can result in values: 1, 2, 3, 4.

As the code is now (before this PR):

`rng.roll_dice(1, MAX_MONSTERS + 2) - 3;`

the possible results are: -2, -1, 0, 1, 2, 3. The for loop will ignore the values -2, -1, 0 because we are comparing the numbers from 0 (0..num_monsters) and thus we can only spawn 0, 1, 2 or 3 monsters. Never 4. The same goes for items. This a bug and this PR fixes the issue.

By offsetting by one the possible results are: 0, 1, 2, 3, 4 and this is the intent of the author I am sure.

Note: it might need to be updated in all future chapters as well (code).

