### PR TITLE
Fix book building

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -6,5 +6,4 @@ src = "src"
 title = "Roguelike Tutorial - In Rust"
 
 [output.html]
-theme = "rust"
 google-analytics = "UA-132191594-2"


### PR DESCRIPTION
# Environment

- ```sh
  $ mdbook --version     
  mdbook v0.4.25
  ```
- Commit: the latest at the moment ([33872fe](https://github.com/amethyst/rustrogueliketutorial/commit/33872fe582f226178436847e1f74eafcbf9c0d1a))

# Without this fix
```
$ mdbook build

2023-01-02 22:07:10 [WARN] (mdbook::book): The output.html.google-analytics field has been deprecated; it will be removed in a future release.
Consider placing the appropriate site tag code into the theme/head.hbs file instead.
The tracking code may be found in the Google Analytics Admin page.

2023-01-02 22:07:10 [INFO] (mdbook::book): Book building has started
2023-01-02 22:07:10 [INFO] (mdbook::book): Running the html backend
2023-01-02 22:07:10 [ERROR] (mdbook::utils): Error: Rendering failed
2023-01-02 22:07:10 [ERROR] (mdbook::utils): 	Caused By: theme dir /home/s373r/src/rust/rustrogueliketutorial/book/rust does not exist

```

# After this fix
```
$ mdbook build

2023-01-02 22:16:02 [INFO] (mdbook::book): Book building has started
2023-01-02 22:16:02 [INFO] (mdbook::book): Running the html backend
```